### PR TITLE
Explain seed argument to foboot-bitstream.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,31 @@ To build the software, you need:
 The hardware half will take care of building the software half, if it is run with `--boot-source bios` (which is the default).  Therefore, to build Foboot, enter the `hw/` directory and run:
 
 ```
-$ python3 foboot-bitstream.py --revision hacker
+$ python3 foboot-bitstream.py --revision hacker --seed 19
 ```
 
 This will verify you have the correct dependencies installed, compile the Foboot software, then synthesize the Foboot bitstream.  The resulting output will be in `build/gateware/`.  You should write `build/gateware/top-multiboot.bin` to your Fomu device in order to get basic bootloader support.
+
+The `seed` argument is to set initial conditions for the
+place-and-route phase.  `nextpnr-ice40` uses a simulated annealing
+algorithm that can result in one of several locally optimal layouts.
+Only some of these will meet the timing requirements for Fomu.
+
+If you see something like
+```
+ERROR: Max frequency for clock 'clk48_$glb_clk': 45.41 MHz (FAIL at 48.00 MHz)
+```
+try a different seed.  You can search for an appropriate seed with:
+```
+for seed in $(seq 0 100)
+do
+  python3 ./foboot-bitstream.py --revision pvt --seed $seed 2>&1 |
+     grep 'FAIL at 48.00 MHz' && continue
+  echo "Working Seed is $seed"
+  break
+done
+```
+This can take a considerable time.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ This can take a considerable time.
 
 ### Usage
 
-You can write the bitstream to your SPI flash.  If you're using `fomu-flash`, you would run the following:
+You can write the bitstream to your SPI flash.
+
+#### Loading using `fomu-flash`
+
+If you're using `fomu-flash`, you would run the following:
 
 ```sh
 $ fomu-flash -w build/gateware/top-multiboot.bin
@@ -72,6 +76,36 @@ Fomu should now show up when you connect it to your machine:
 [172294.445692] usb 1-1.3: Manufacturer: Kosagi
 ```
 
+#### Using `dfu-util` to flash the bootloader
+
+First build the flasher program, that will run on the Fomu:
+```sh
+cd booster
+cc -O2 -o make-booster -I ./include make-booster.c
+```
+
+Then package that up ready for loading:
+```sh
+cd releases
+bash ./release.sh pvt
+```
+This will create a new directory in `releases` named by the head of
+your git tree and the last official release.  So you'll see something
+like `v2.0.3-8-g485d232`
+
+In that directory will be a file named `pvt-updater-`_version_`.dfu`
+Load and exectue it using `dfu-util`:
+```sh
+dfu-util -D pvt-updater-v2.0.3-8-g485d232.dfu
+```
+Your Fomu will flash rainbow for about five seconds, then reboot and
+go back to blinking steadily.   To verify that your code has loaded, use
+```sh
+dfu-util -l
+```
+and look at the version output.
+
+#### Loading and running other bitstreams
 To load a new bitstream, use the `dfu-util -D` command.  For example:
 
 ```sh
@@ -87,6 +121,7 @@ $ dfu-util -e
 ```
 
 **Note that, like Toboot, the program will auto-boot once it has finished loading.**
+
 
 ## Building the Software
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,40 @@ Fomu should now show up when you connect it to your machine:
 
 #### Using `dfu-util` to flash the bootloader
 
-First build the flasher program, that will run on the Fomu:
+##### Safe way to test
+
+Just do
+```sh
+dfu-util -D build/gateware/top.bin
+```
+to copy into the SPI flash, then
+```sh
+dfu-util -e
+```
+each time you want to run the generated bitstream after a reboot.
+
+A multiboot enabled bootloader is also generated; you can try that out
+with
+```sh
+dfu-util -D build/gateware/top-multiboot.bin
+```
+
+`dfu-util` loads the bootloader into flash at 0x40000; it'll be overridden
+by any other code you attempt to flash using `dfu-util`
+
+##### Loading the bootloader as first bootloader
+
+**WARNING: Flashing a new bootloader could _brick your device_**
+**It's best to wait for an official release**
+
+First build the flasher program, that will run on the Fomu (you only
+need to do this once):
 ```sh
 cd booster
 cc -O2 -o make-booster -I ./include make-booster.c
 ```
 
-Then package that up ready for loading:
+Then package everything up ready for loading:
 ```sh
 cd releases
 bash ./release.sh pvt
@@ -94,7 +121,7 @@ your git tree and the last official release.  So you'll see something
 like `v2.0.3-8-g485d232`
 
 In that directory will be a file named `pvt-updater-`_version_`.dfu`
-Load and exectue it using `dfu-util`:
+Load  it onto the Fomu using `dfu-util`:
 ```sh
 dfu-util -D pvt-updater-v2.0.3-8-g485d232.dfu
 ```
@@ -121,7 +148,6 @@ $ dfu-util -e
 ```
 
 **Note that, like Toboot, the program will auto-boot once it has finished loading.**
-
 
 ## Building the Software
 


### PR DESCRIPTION
Update README to say what to do if the place-and-route process fails
to find an appropriate solution.

Fixes #45 