### PR TITLE
Add makefile options to simplify compiling for RAM boot

### DIFF
--- a/doc/BOOT-SEQUENCE.md
+++ b/doc/BOOT-SEQUENCE.md
@@ -14,7 +14,7 @@ At start, **FBU** is loaded by the hardware.  **FBU** will look for a special *F
 
 ## Boot Flags
 
-A series of *Boot Flags* determine hows **FBU** and **FBM** hand over execution to the subsequent program.
+A series of *Boot Flags* determines how **FBU** and **FBM** hand over execution to the subsequent program.
 
 *Boot Flags* are indicated by the magic number `0xb469075a`, followed by a
 32-bit field, in the first 128 bytes of the binary.

--- a/doc/BOOT-SEQUENCE.md
+++ b/doc/BOOT-SEQUENCE.md
@@ -14,7 +14,7 @@ At start, **FBU** is loaded by the hardware.  **FBU** will look for a special *F
 
 ## Boot Flags
 
-A series of *Boot Fags* determine how **FBU** and **FBM** hand over execution to the subsequent program.
+A series of *Boot Flags* determine hows **FBU** and **FBM** hand over execution to the subsequent program.
 
 *Boot Flags* are indicated by the magic number `0xb469075a`, followed by a
 32-bit field, in the first 128 bytes of the binary.
@@ -27,6 +27,8 @@ struct {
     uint32_t bitfield;
 }
 ```
+
+These can be provided when making the program (when using a Makefile as in `examples/riscv-blink`), e.g. `make LOAD_BOOT_CONFIG=0x00000020`.
 
 | Bit Flag | Short Name   | Description                                      |
 | -------- | ------------ | ------------------------------------------------ |
@@ -44,6 +46,8 @@ During development, it may be inconvenient to load a program onto SPI flash.  Or
 If the DFU bootloader encounters the magic number `0x17ab0f23` within the first 56 bytes, then it will enable *RAM boot* mode.  In this mode, the SPI flash won't be erased, and the program will be loaded to RAM.
 
 Note that the value following the magic number indicates the offset where the program will be loaded to.  This should be somewhere in RAM.  `0x10001000` is a good value, and is guaranteed to not interfere with Foboot itself.
+
+When using a Makefile as in `examples/riscv-blink` you can provide the offset as in `make LOAD_RAM_ADDR=0x10001000`. This makes sure that the linker links the binary as one block.
 
 ## Magic Numbers
 

--- a/examples/riscv-blink/Makefile
+++ b/examples/riscv-blink/Makefile
@@ -34,7 +34,9 @@ THIRD_PARTY := $(BASE_DIR)/third_party
 DBG_CFLAGS := -ggdb -g -DDEBUG -Wall
 DBG_LFLAGS := -ggdb -g -Wall
 CFLAGS     := $(ADD_CFLAGS) \
+			  -D__vexriscv__ -march=rv32i  -mabi=ilp32 \
 			  -Wall -Wextra \
+			  -flto \
 			  -ffunction-sections -fdata-sections -fno-common \
 			  -fomit-frame-pointer -Os \
 			  -march=rv32i \
@@ -42,6 +44,7 @@ CFLAGS     := $(ADD_CFLAGS) \
 CXXFLAGS   := $(CFLAGS) -std=c++11 -fno-rtti -fno-exceptions
 LFLAGS     := $(CFLAGS) $(ADD_LFLAGS) -L$(LD_DIR) \
 			  -nostartfiles \
+			  -nostdlib \
 			  -Wl,--gc-sections \
 			  -Wl,--no-warn-mismatch \
 			  -Wl,--script=$(LDSCRIPT) \
@@ -64,7 +67,7 @@ ALL        := all
 TARGET     := $(PACKAGE).elf
 CLEAN      := clean
 
-$(ALL): $(TARGET) $(PACKAGE).bin $(PACKAGE).ihex
+$(ALL): $(TARGET) $(PACKAGE).bin $(PACKAGE).ihex $(PACKAGE).dfu
 
 $(OBJECTS): | $(OBJ_DIR)
 
@@ -76,7 +79,7 @@ $(PACKAGE).bin: $(TARGET)
 	$(QUIET) echo "  OBJCOPY  $@"
 	$(QUIET) $(OBJCOPY) -O binary $(TARGET) $@
 
-$(PACKAGE).dfu: $(TARGET)
+$(PACKAGE).dfu: $(PACKAGE).bin
 	$(QUIET) echo "  DFU      $@"
 	$(QUIET) $(COPY) $(PACKAGE).bin $@
 	$(QUIET) dfu-suffix -v 1209 -p 70b1 -a $@
@@ -106,7 +109,7 @@ $(OBJ_DIR)/%.o: %.S
 	$(QUIET) echo "  AS       $<	$(notdir $@)"
 	$(QUIET) $(CC) -x assembler-with-cpp -c $< $(CFLAGS) -o $@ -MMD
 
-.PHONY: clean
+.PHONY: clean load
 
 clean:
 	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.d))"
@@ -116,4 +119,8 @@ clean:
 	$(QUIET) echo "  RM      $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol $(PACKAGE).ihex $(PACKAGE).dfu"
 	-$(QUIET) $(RM) $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol $(PACKAGE).ihex $(PACKAGE).dfu
 
+load: $(PACKAGE).dfu
+	$(QUIET) dfu-util -D $<
+
 include $(wildcard $(OBJ_DIR)/*.d)
+

--- a/examples/riscv-blink/Makefile
+++ b/examples/riscv-blink/Makefile
@@ -26,9 +26,21 @@ LD_DIR     := $(BASE_DIR)/ld
 LDSCRIPT   := $(BASE_DIR)/ld/linker.ld
 ADD_CFLAGS := -I$(BASE_DIR)/include -D__vexriscv__ -march=rv32i  -mabi=ilp32
 ADD_LFLAGS := 
-PACKAGE    := example
+PACKAGE    := riscv-blink
 
-LDSCRIPTS  := $(LDSCRIPT) $(LD_DIR)/output_format.ld $(LD_DIR)/regions.ld
+ifdef LOAD_RAM_ADDR
+LDREGIONS  := $(LD_DIR)/regions_ram.ld
+ADD_CFLAGS += -DLOAD_RAM_ADDR=$(LOAD_RAM_ADDR)
+ADD_LFLAGS += -Wl,--defsym=LOAD_RAM_ADDR=$(LOAD_RAM_ADDR)
+else
+LDREGIONS  := $(LD_DIR)/regions.ld
+endif
+
+ifdef LOAD_BOOT_CONFIG
+ADD_CFLAGS += -DLOAD_BOOT_CONFIG=$(LOAD_BOOT_CONFIG)
+endif
+
+LDSCRIPTS  := $(LDSCRIPT) $(LDREGIONS) $(LD_DIR)/output_format.ld
 SRC_DIR    := $(BASE_DIR)/src
 THIRD_PARTY := $(BASE_DIR)/third_party
 DBG_CFLAGS := -ggdb -g -DDEBUG -Wall
@@ -47,6 +59,7 @@ LFLAGS     := $(CFLAGS) $(ADD_LFLAGS) -L$(LD_DIR) \
 			  -nostdlib \
 			  -Wl,--gc-sections \
 			  -Wl,--no-warn-mismatch \
+			  -Wl,--script=$(LDREGIONS) \
 			  -Wl,--script=$(LDSCRIPT) \
 			  -Wl,--build-id=none
 

--- a/examples/riscv-blink/ld/linker.ld
+++ b/examples/riscv-blink/ld/linker.ld
@@ -3,8 +3,6 @@ ENTRY(_start)
 
 __DYNAMIC = 0;
 
-INCLUDE regions.ld
-
 SECTIONS
 {
 	.text :

--- a/examples/riscv-blink/ld/regions_ram.ld
+++ b/examples/riscv-blink/ld/regions_ram.ld
@@ -1,0 +1,5 @@
+MEMORY {
+	ram : ORIGIN = LOAD_RAM_ADDR, LENGTH = 0x00010000
+}
+REGION_ALIAS("rom", ram)
+REGION_ALIAS("sram", ram)

--- a/examples/riscv-blink/src/crt0-vexriscv.S
+++ b/examples/riscv-blink/src/crt0-vexriscv.S
@@ -6,8 +6,14 @@
 
 _start:
   j crt_init
+#ifdef LOAD_RAM_ADDR
+  .word 0x17ab0f23
+  .word LOAD_RAM_ADDR
+#endif
+#ifdef LOAD_BOOT_CONFIG
   .word 0xb469075a
-  .word 0x00000020
+  .word LOAD_BOOT_CONFIG
+#endif
 
 .section .text
 .global  trap_entry

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -37,7 +37,19 @@ ADD_LFLAGS :=
 PACKAGE    := foboot
 endif
 
-LDSCRIPTS  := $(LDSCRIPT) $(LD_DIR)/output_format.ld $(LD_DIR)/regions.ld
+ifdef LOAD_RAM_ADDR
+LDREGIONS  := $(LD_DIR)/regions_ram.ld
+ADD_CFLAGS += -DLOAD_RAM_ADDR=$(LOAD_RAM_ADDR)
+ADD_LFLAGS += -Wl,--defsym=LOAD_RAM_ADDR=$(LOAD_RAM_ADDR)
+else
+LDREGIONS  := $(LD_DIR)/regions.ld
+endif
+
+ifdef LOAD_BOOT_CONFIG
+ADD_CFLAGS += -DLOAD_BOOT_CONFIG=$(LOAD_BOOT_CONFIG)
+endif
+
+LDSCRIPTS  := $(LDSCRIPT) $(LDREGIONS) $(LD_DIR)/output_format.ld
 SRC_DIR    := $(BASE_DIR)/src
 THIRD_PARTY := $(BASE_DIR)/third_party
 DBG_CFLAGS := -ggdb3 -DDEBUG -Wall
@@ -56,6 +68,7 @@ LFLAGS     := $(CFLAGS) $(ADD_LFLAGS) -L$(LD_DIR) \
 			  -nostdlib \
 			  -Wl,--gc-sections \
 			  -Wl,--no-warn-mismatch \
+			  -Wl,--script=$(LDREGIONS) \
 			  -Wl,--script=$(LDSCRIPT) \
 			  -Wl,--build-id=none
 

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -76,7 +76,7 @@ ALL        := all
 TARGET     := $(PACKAGE).elf
 CLEAN      := clean
 
-$(ALL): $(TARGET) $(PACKAGE).bin $(PACKAGE).ihex
+$(ALL): $(TARGET) $(PACKAGE).bin $(PACKAGE).ihex $(PACKAGE).dfu
 
 $(OBJECTS): | $(OBJ_DIR)
 
@@ -88,7 +88,7 @@ $(PACKAGE).bin: $(TARGET)
 	$(QUIET) echo "  OBJCOPY  $@"
 	$(QUIET) $(OBJCOPY) -O binary $(TARGET) $@
 
-$(PACKAGE).dfu: $(TARGET)
+$(PACKAGE).dfu: $(PACKAGE).bin
 	$(QUIET) echo "  DFU      $@"
 	$(QUIET) $(COPY) $(PACKAGE).bin $@
 	$(QUIET) dfu-suffix -v 1209 -p 70b1 -a $@
@@ -118,7 +118,7 @@ $(OBJ_DIR)/%.o: %.S
 	$(QUIET) echo "  AS       $<	$(notdir $@)"
 	$(QUIET) $(CC) -x assembler-with-cpp -c $< $(CFLAGS) -o $@ -MMD
 
-.PHONY: clean
+.PHONY: clean load
 
 clean:
 	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.d))"
@@ -128,4 +128,8 @@ clean:
 	$(QUIET) echo "  RM      $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol $(PACKAGE).ihex $(PACKAGE).dfu"
 	-$(QUIET) $(RM) $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol $(PACKAGE).ihex $(PACKAGE).dfu
 
+load: $(PACKAGE).dfu
+	$(QUIET) dfu-util -D $<
+
 include $(wildcard $(OBJ_DIR)/*.d)
+

--- a/sw/ld/linker.ld
+++ b/sw/ld/linker.ld
@@ -3,8 +3,6 @@ ENTRY(_start)
 
 __DYNAMIC = 0;
 
-INCLUDE regions.ld
-
 SECTIONS
 {
 	.text :

--- a/sw/ld/regions_ram.ld
+++ b/sw/ld/regions_ram.ld
@@ -1,0 +1,5 @@
+MEMORY {
+	ram : ORIGIN = LOAD_RAM_ADDR, LENGTH = 0x00010000
+}
+REGION_ALIAS("rom", ram)
+REGION_ALIAS("sram", ram)

--- a/sw/third_party/libbase/crt0-vexriscv.S
+++ b/sw/third_party/libbase/crt0-vexriscv.S
@@ -7,10 +7,20 @@
 _start:
   j crt_init
   nop
+#ifdef LOAD_RAM_ADDR
+  .word 0x17ab0f23
+  .word LOAD_RAM_ADDR
+#else
   nop
   nop
+#endif
+#ifdef LOAD_BOOT_CONFIG
+  .word 0xb469075a
+  .word LOAD_BOOT_CONFIG
+#else
   nop
   nop
+#endif
   nop
   nop
 


### PR DESCRIPTION
RAM boot requires adding the magic word and different linking (as one block).
This PR simplifies this process by adding this adds the make option `LOAD_RAM_ADDR` (for `sw/Makefile` which I needed to quickly test changes to the bootloader, and to `examples/riscv-blink/Makefile` as an example for a user program):
```
make LOAD_RAM_ADDR=0x10001000
```
Also, this adds, in a similar line, the make option `LOAD_BOOT_CONFIG` to add the boot config word.