### PR TITLE
Add optional auto-boot after timeout

### DIFF
--- a/doc/BOOT-SEQUENCE.md
+++ b/doc/BOOT-SEQUENCE.md
@@ -39,7 +39,7 @@ struct {
 
 ## Auto-boot
 
-A user program can provide a timeout between 1s and 255s, after which it is automatically loaded by the boot loader (given the user does not load a new programm in the meantime).
+A user program can provide a timeout between 1s and 255s, after which it is automatically loaded by the boot loader. Uploading a new program via USB will cancel this timeout.
 
 The timeout must be given in the third (4-byte little-endian) word of the programm and must be preceeded by the magic word `0x4a6de3ac` in the second word. For bitstreams these can be added using the `examples/add_timeout.py` script, for RISC-V programs use the make file option `make AUTOBOOT_TIMEOUT=5` (e.g., for 5s; when using a Makefile as in `examples/riscv-blink`).
 

--- a/doc/BOOT-SEQUENCE.md
+++ b/doc/BOOT-SEQUENCE.md
@@ -37,6 +37,12 @@ struct {
 | 00000010 | FLUSH_CACHE  | Issue a "fence.i" prior to running user program  |
 | 00000020 | NO_USB_RESET | Don't reset the USB -- useful for debugging      |
 
+## Auto-boot
+
+A user program can provide a timeout between 1s and 255s, after which it is automatically loaded by the boot loader (given the user does not load a new programm in the meantime).
+
+The timeout must be given in the third (4-byte little-endian) word of the programm and must be preceeded by the magic word `0x4a6de3ac` in the second word. For bitstreams these can be added using the `examples/add_timeout.py` script, for RISC-V programs use the make file option `make AUTOBOOT_TIMEOUT=5` (e.g., for 5s; when using a Makefile as in `examples/riscv-blink`).
+
 ## RAM boot
 
 During development, it may be inconvenient to load a program onto SPI flash.  Or maybe you want to run something that doesn't modify the contents of SPI.  This is possible with `RAM boot`.
@@ -47,8 +53,9 @@ Note that the value following the magic number indicates the offset where the pr
 
 ## Magic Numbers
 
-| Value        | Description                                 |
-| ------------ | ------------------------------------------- |
-| `0xb469075a` | Denotes the start of *boot flags* bitfield  |
-| `0x17ab0f23` | Loads the program into RAM instead of flash |
-| `0x032bd37d` | Indicates a valid **FBM** image             |
+| Value        | Description                                                    |
+| ------------ | -------------------------------------------------------------- |
+| `0xb469075a` | Denotes the start of *boot flags* bitfield                     |
+| `0x17ab0f23` | Loads the program into RAM instead of flash                    |
+| `0x032bd37d` | Indicates a valid **FBM** image                                |
+| `0x4a6de3ac` | Auto-boot user image after timeout (1-255s) given in next word |

--- a/examples/add_autoboot_timeout.py
+++ b/examples/add_autoboot_timeout.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="Add auto-boot timeout to bitstream")
+parser.add_argument("infile", type=str)
+parser.add_argument("outfile", type=str)
+parser.add_argument("--timeout", type=int, default=5)
+args = parser.parse_args()
+
+COMMENT_START = 0x00FF
+COMMENT_END = 0xFF00
+MAGIC_WORD = 0x4A6DE3AC
+BITSTREAM_SYNC_HEADER1 = 2123999870
+BITSTREAM_SYNC_HEADER2 = 2125109630
+ENDIANNESS = "little"
+
+
+def to_bytes(v, n=4):
+    return v.to_bytes(n, byteorder=ENDIANNESS, signed=False)
+
+
+def from_bytes(v):
+    return int.from_bytes(v, byteorder=ENDIANNESS)
+
+
+if args.timeout < 1 or args.timeout > 255:
+    sys.stderr.write("Pick a timeout between 1s and 255s")
+    sys.exit(1)
+
+with open(args.infile, "rb") as infile:
+    with open(args.outfile, "wb") as outfile:
+        first_word = from_bytes(infile.read(4))
+        if (
+            first_word != BITSTREAM_SYNC_HEADER1
+            and first_word != BITSTREAM_SYNC_HEADER2
+            and first_word & 0xFFFF != COMMENT_START
+        ):
+            sys.stderr.write("Unsupported file")
+            sys.exit(1)
+        outfile.write(to_bytes(COMMENT_START))
+        outfile.write(to_bytes(MAGIC_WORD))
+        outfile.write(to_bytes(args.timeout))
+        if first_word & 0xFFFF == COMMENT_START:  # there already is a comments section
+            outfile.write(to_bytes(0, n=2))  # make sure alignment is correct
+            outfile.write(to_bytes(first_word >> 16, n=2))
+        else:
+            outfile.write(to_bytes(COMMENT_END))
+        outfile.write(infile.read())

--- a/examples/add_autoboot_timeout.py
+++ b/examples/add_autoboot_timeout.py
@@ -25,7 +25,7 @@ def from_bytes(v):
 
 
 if args.timeout < 1 or args.timeout > 255:
-    sys.stderr.write("Pick a timeout between 1s and 255s")
+    sys.stderr.write("Error: Pick a timeout between 1s and 255s")
     sys.exit(1)
 
 with open(args.infile, "rb") as infile:
@@ -36,7 +36,10 @@ with open(args.infile, "rb") as infile:
             and first_word != BITSTREAM_SYNC_HEADER2
             and first_word & 0xFFFF != COMMENT_START
         ):
-            sys.stderr.write("Unsupported file")
+            sys.stderr.write("Error: File does not appear to be a bitstream")
+            sys.stderr.write(
+                "(for RISC-V programs use the AUTOBOOT_TIMEOUT make option)"
+            )
             sys.exit(1)
         outfile.write(to_bytes(COMMENT_START))
         outfile.write(to_bytes(MAGIC_WORD))

--- a/examples/riscv-blink/Makefile
+++ b/examples/riscv-blink/Makefile
@@ -28,6 +28,10 @@ ADD_CFLAGS := -I$(BASE_DIR)/include -D__vexriscv__ -march=rv32i  -mabi=ilp32
 ADD_LFLAGS := 
 PACKAGE    := example
 
+ifdef AUTOBOOT_TIMEOUT
+ADD_CFLAGS += -DAUTOBOOT_TIMEOUT=$(AUTOBOOT_TIMEOUT)
+endif
+
 LDSCRIPTS  := $(LDSCRIPT) $(LD_DIR)/output_format.ld $(LD_DIR)/regions.ld
 SRC_DIR    := $(BASE_DIR)/src
 THIRD_PARTY := $(BASE_DIR)/third_party

--- a/examples/riscv-blink/src/crt0-vexriscv.S
+++ b/examples/riscv-blink/src/crt0-vexriscv.S
@@ -6,6 +6,10 @@
 
 _start:
   j crt_init
+#ifdef AUTOBOOT_TIMEOUT
+  .word 0x4a6de3ac
+  .word AUTOBOOT_TIMEOUT
+#endif
   .word 0xb469075a
   .word 0x00000020
 

--- a/sw/src/main.c
+++ b/sw/src/main.c
@@ -24,6 +24,15 @@ void isr(void)
 
     if (irqs & (1 << USB_INTERRUPT))
         usb_isr();
+
+    if (irqs & (1 << TIMER0_INTERRUPT)) {
+        timer0_ev_pending_write(timer0_ev_pending_read());
+        if (dfu_getstate() == dfuIDLE) {
+            reboot();
+            while (1)
+                ;
+        }
+    }
 }
 
 static void riscv_reboot_to(const void *addr, uint32_t boot_config) {
@@ -201,6 +210,29 @@ void reboot(void) {
     __builtin_unreachable();
 }
 
+static void init_timeout(void) {
+    uint8_t timeout = 0;
+
+    lxspi_bitbang_en_write(0);
+    uint32_t reboot_addr = dfu_origin_addr();
+    uint32_t *addr = (uint32_t *)reboot_addr;
+    if (addr[1] == 0x4a6de3ac) {
+        timeout = addr[2] & 0xff;
+    }
+    lxspi_bitbang_en_write(1);
+
+    if (timeout) {
+        timer0_en_write(0);
+        timer0_reload_write(0);
+        timer0_load_write(timeout * CONFIG_CLOCK_FREQUENCY);
+        timer0_en_write(1);
+        timer0_update_value_write(0);
+        timer0_ev_pending_write(timer0_ev_pending_read());
+        irq_setmask(irq_getmask() | (1 << TIMER0_INTERRUPT));
+        timer0_ev_enable_write(1);
+    }
+}
+
 static void init(void)
 {
 #ifdef FLASH_BOOT_ADDRESS
@@ -229,6 +261,7 @@ static void init(void)
     irq_setie(1);
     time_init();
     dfu_init();
+    init_timeout();
 }
 
 int main(int argc, char **argv)

--- a/sw/src/main.c
+++ b/sw/src/main.c
@@ -11,6 +11,8 @@
 
 struct ff_spi *spi;
 
+static int nerve_pinch(void);
+
 // ICE40UP5K bitstream images (with SB_MULTIBOOT header) are
 // 104250 bytes.  The SPI flash has 4096-byte erase blocks.
 // The smallest divisible boundary is 4096*26.
@@ -27,7 +29,7 @@ void isr(void)
 
     if (irqs & (1 << TIMER0_INTERRUPT)) {
         timer0_ev_pending_write(timer0_ev_pending_read());
-        if (dfu_getstate() == dfuIDLE) {
+        if (dfu_getstate() == dfuIDLE && !nerve_pinch()) {
             reboot();
             while (1)
                 ;


### PR DESCRIPTION
This PR addresses #24 and im-tomu/fomu-workshop#52 by adding the option to auto-boot a user image.

The user image can provide a timeout between 1s and 255s, after which it is automatically loaded by the boot loader (given the user does not load a new programm in the meantime). The timeout must be given in the third (4-byte little-endian) word of the programm and must be preceeded by the magic word `0x4a6de3ac` in the second word.

For bitstreams these words can be added using the added `examples/add_timeout.py` script, for RISC-V programs this PR adds ae make file option to the Makefile in `examples/riscv-blink`; e.g. for 5s: `make AUTOBOOT_TIMEOUT=5`