### PR TITLE
Add 'make' to the instructions (to make booster.bin).

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ need to do this once):
 ```sh
 cd booster
 cc -O2 -o make-booster -I ./include make-booster.c
+make
 ```
 
 Then package everything up ready for loading:

--- a/doc/FLASHLAYOUT.md
+++ b/doc/FLASHLAYOUT.md
@@ -8,4 +8,4 @@
 | 0x026800 | 157696  |  The second image for SB_WARMBOOT |
 | 0x040000 | 262144  |  The third image for SB_WARMBOOT |
 | 0x048000 | 294912  |  The third image for SB_WARMBOOT |
-| 0x1FFFFF | 20097151 | End of flash |
+| 0x1FFFFF | 2097151 | End of flash |


### PR DESCRIPTION
Fixes issue #187 . 

Also fix a typo in flash addresses.

Signed-off-by: Tim Callahan <tcal@google.com>