### PR TITLE
Adjust doc, suggest different address for RAM LOAD.

### DIFF
--- a/doc/BOOT-SEQUENCE.md
+++ b/doc/BOOT-SEQUENCE.md
@@ -51,9 +51,9 @@ During development, it may be inconvenient to load a program onto SPI flash.  Or
 
 If the DFU bootloader encounters the magic number `0x17ab0f23` within the first 56 bytes, then it will enable *RAM boot* mode.  In this mode, the SPI flash won't be erased, and the program will be loaded to RAM.
 
-Note that the value following the magic number indicates the offset where the program will be loaded to.  This should be somewhere in RAM.  `0x10001000` is a good value, and is guaranteed to not interfere with Foboot itself.
+Note that the value following the magic number indicates the offset where the program will be loaded to.  This should be somewhere in RAM.  `0x10002000` is a good value, and is guaranteed to not interfere with Foboot itself.
 
-When using a Makefile as in `examples/riscv-blink` you can provide the offset as in `make LOAD_RAM_ADDR=0x10001000`. This makes sure that the linker links the binary as one block.
+When using a Makefile as in `examples/riscv-blink` you can provide the offset as in `make LOAD_RAM_ADDR=0x10002000`. This makes sure that the linker links the binary as one block.
 
 ## Magic Numbers
 


### PR DESCRIPTION
It seems BIOS is now using RAM up to 0x10001200, so loading the RISCV binary to 0x10001000 causes problems that I reported in issue #198 .   

Since we have up to 0x10020000, it seems safe to bump up the  suggested address for the RAM LOAD of the RISCV binary to 0x10002000.  I tested this with foboot v2.0.3, and riscv-blinky works.

Signed-off-by: Tim Callahan <tcal@google.com>
